### PR TITLE
Conventions plugin should not depend on order

### DIFF
--- a/plugins/elastic-conventions/src/integrationTest/java/co/elastic/gradle/elatic_conventions/ElasticConventionsPluginIT.java
+++ b/plugins/elastic-conventions/src/integrationTest/java/co/elastic/gradle/elatic_conventions/ElasticConventionsPluginIT.java
@@ -95,9 +95,9 @@ public class ElasticConventionsPluginIT extends TestkitIntegrationTest {
                    import %s
                    import %s
                    plugins {
+                       id("co.elastic.elastic-conventions")
                        id("co.elastic.cli.jfrog")
                        id("co.elastic.cli.manifest-tool")
-                       id("co.elastic.elastic-conventions")
                    }
                                   
                    val jfrog by tasks.registering(JFrogCliExecTask::class)
@@ -111,7 +111,7 @@ public class ElasticConventionsPluginIT extends TestkitIntegrationTest {
         );
 
         final BuildResult result = gradleRunner
-                .withArguments("--warning-mode", "fail", "-s", "check")
+                .withArguments("--warning-mode", "fail", "-s", "check", "--refresh-dependencies")
                 .build();
 
         System.out.println(result.getOutput());

--- a/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
+++ b/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
@@ -142,19 +142,23 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
         plugins.withType(BaseCliPlugin.class, unused -> {
             plugins.apply(VaultPlugin.class);
             final VaultExtension vault = target.getExtensions().getByType(VaultExtension.class);
-            final CliExtension cliExtension = target.getExtensions().getByType(CliExtension.class);
-            var listOfNames = new ArrayList<String>();
-            for (ExtensionsSchema.ExtensionSchema extensionSchema : cliExtension.getExtensions().getExtensionsSchema()) {
-                if (extensionSchema.getPublicType().isAssignableFrom(BaseCLiExtension.class)) {
-                    listOfNames.add(extensionSchema.getName());
+
+            target.afterEvaluate(t -> {
+                final CliExtension cliExtension = target.getExtensions().getByType(CliExtension.class);
+
+                var listOfNames = new ArrayList<String>();
+                for (ExtensionsSchema.ExtensionSchema extensionSchema : cliExtension.getExtensions().getExtensionsSchema()) {
+                    if (extensionSchema.getPublicType().isAssignableFrom(BaseCLiExtension.class)) {
+                        listOfNames.add(extensionSchema.getName());
+                    }
                 }
-            }
-            var creds = vault.readAndCacheSecret(getVaultArtifactoryPath()).get();
-            for (String name : listOfNames) {
-                final BaseCLiExtension extension = (BaseCLiExtension) cliExtension.getExtensions().getByName(name);
-                extension.getUsername().set(creds.get("username"));
-                extension.getPassword().set(creds.get("plaintext"));
-            }
+                var creds = vault.readAndCacheSecret(getVaultArtifactoryPath()).get();
+                for (String name : listOfNames) {
+                    final BaseCLiExtension extension = (BaseCLiExtension) cliExtension.getExtensions().getByName(name);
+                    extension.getUsername().set(creds.get("username"));
+                    extension.getPassword().set(creds.get("plaintext"));
+                }
+            });
         });
     }
 


### PR DESCRIPTION
Without this fix if the conventions plugin is applied before the CLI
plugins, it would not configure them correctly.

This would work:
```
plugins {
    id("co.elastic.docker-base")
    id("co.elastic.docker-component")
    id("co.elastic.elastic-conventions")
}
```

But not this:
```
plugins {
    id("co.elastic.elastic-conventions")
    id("co.elastic.docker-base")
    id("co.elastic.docker-component")
}

```
