### PR TITLE
Fix the Elatic Conventions plugin to work with multi project builds

### DIFF
--- a/plugins/cli/jfrog/src/main/java/co/elastic/gradle/cli/jfrog/JFrogPlugin.java
+++ b/plugins/cli/jfrog/src/main/java/co/elastic/gradle/cli/jfrog/JFrogPlugin.java
@@ -37,12 +37,14 @@ import java.util.Arrays;
 
 public abstract class JFrogPlugin implements Plugin<Project> {
 
+    public static final String EXTENSION_NAME = "jfrog";
+
     @Override
     public void apply(Project target) {
         target.getPluginManager().apply(BaseCliPlugin.class);
         final BaseCLiExtension extension = target.getExtensions().getByType(CliExtension.class)
                 .getExtensions()
-                .create("jfrog", BaseCLiExtension.class);
+                .create(EXTENSION_NAME, BaseCLiExtension.class);
         extension.getVersion().convention("2.16.4");
         extension.getPattern().convention("[organisation]/[module]/v2-jf/[revision]/[module]-[classifier]/jf");
         try {

--- a/plugins/cli/jfrog/src/main/java/co/elastic/gradle/cli/jfrog/JFrogPlugin.java
+++ b/plugins/cli/jfrog/src/main/java/co/elastic/gradle/cli/jfrog/JFrogPlugin.java
@@ -37,7 +37,7 @@ import java.util.Arrays;
 
 public abstract class JFrogPlugin implements Plugin<Project> {
 
-    public static final String EXTENSION_NAME = "jfrog";
+    private static final String EXTENSION_NAME = "jfrog";
 
     @Override
     public void apply(Project target) {

--- a/plugins/elastic-conventions/build.gradle.kts
+++ b/plugins/elastic-conventions/build.gradle.kts
@@ -22,14 +22,16 @@ dependencies {
     implementation(project(":plugins:lifecycle"))
     implementation(project(":plugins:vault"))
     implementation(project(":plugins:cli:cli-lib"))
+    implementation(project(":plugins:cli:jfrog"))
+    implementation(project(":plugins:cli:manifest-tool"))
+    implementation(project(":plugins:cli:shellcheck"))
     implementation(project(":plugins:cli:snyk"))
     implementation(project(":plugins:docker:base-image"))
+    implementation(project(":plugins:docker:component-image"))
 
     integrationTestImplementation(project(":plugins:vault"))
-    // for integration testing only
-    implementation(project(":plugins:cli:jfrog"))
     integrationTestImplementation(project(":plugins:cli:jfrog"))
-    implementation(project(":plugins:cli:manifest-tool"))
+    integrationTestImplementation(project(":plugins:cli:shellcheck"))
+    integrationTestImplementation(project(":plugins:cli:snyk"))
     integrationTestImplementation(project(":plugins:cli:manifest-tool"))
-    implementation(project(":plugins:docker:component-image"))
 }

--- a/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
+++ b/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
@@ -106,8 +106,10 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
     public void applyToProject(Project target) {
         final PluginContainer plugins = target.getPlugins();
         plugins.apply(LifecyclePlugin.class);
+        plugins.apply(VaultPlugin.class);
+        final VaultExtension vault = target.getExtensions().getByType(VaultExtension.class);
         plugins.withType(VaultPlugin.class, unused ->
-                configureVaultPlugin(target.getExtensions().getByType(VaultExtension.class))
+                configureVaultPlugin(vault)
         );
         target.getRootProject().getPlugins().withType(VaultPlugin.class, unused ->
                 configureVaultPlugin(target.getRootProject().getExtensions().getByType(VaultExtension.class))
@@ -115,20 +117,19 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
 
         configureCliPlugins(target);
 
-
-
-        target.getPlugins().withType(DockerBaseImageBuildPlugin.class, unused -> {
-            plugins.apply(VaultPlugin.class);
-            final BaseImageExtension extension = target.getExtensions().getByType(BaseImageExtension.class);
-            final VaultExtension vault = target.getExtensions().getByType(VaultExtension.class);
-
-            target.getTasks().withType(SnykCLIExecTask.class, task ->
+        target.afterEvaluate(unused -> {
+                target.getTasks().withType(SnykCLIExecTask.class, task -> {
+                    target.getLogger().info("Configuring Snyk token env var for " + task.getPath());
                     task.environment(
                             "SNYK_TOKEN",
                             vault.readAndCacheSecret(getSnykVaultPath()).get().get("apikey")
-                    )
-            );
+                    );
+                });
+        });
 
+        target.getPlugins().withType(DockerBaseImageBuildPlugin.class, unused -> {
+            target.getPlugins().apply(VaultPlugin.class);
+            final BaseImageExtension extension = target.getExtensions().getByType(BaseImageExtension.class);
             var creds = vault.readAndCacheSecret(getVaultArtifactoryPath()).get();
             try {
                 extension.getOsPackageRepository().set(new URL(
@@ -142,15 +143,10 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
     }
 
     private void configureCliPlugins(Project target) {
-        // BaseCli project works on the root project, need to configure it there
-        final Project rootProject = target.getRootProject();
-        rootProject.getPlugins().withType(BaseCliPlugin.class, unused -> {
-            rootProject.getPlugins().apply(VaultPlugin.class);
-            final VaultExtension vault = rootProject.getRootProject().getExtensions().getByType(VaultExtension.class);
-
-            rootProject.afterEvaluate(t -> {
-                final CliExtension cliExtension = rootProject.getExtensions().getByType(CliExtension.class);
-
+        final VaultExtension vault = target.getExtensions().getByType(VaultExtension.class);
+        target.afterEvaluate(unused ->
+            target.getPlugins().withType(BaseCliPlugin.class, u -> {
+                final CliExtension cliExtension = target.getExtensions().getByType(CliExtension.class);
                 var listOfNames = new ArrayList<String>();
                 for (ExtensionsSchema.ExtensionSchema extensionSchema : cliExtension.getExtensions().getExtensionsSchema()) {
                     if (extensionSchema.getPublicType().isAssignableFrom(BaseCLiExtension.class)) {
@@ -163,8 +159,8 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
                     extension.getUsername().set(creds.get("username"));
                     extension.getPassword().set(creds.get("plaintext"));
                 }
-            });
-        });
+            })
+        );
     }
 
     public void applyToSettings(Settings target) {

--- a/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
+++ b/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
@@ -143,12 +143,13 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
 
     private void configureCliPlugins(Project target) {
         // BaseCli project works on the root project, need to configure it there
-        target.getRootProject().getPlugins().withType(BaseCliPlugin.class, unused -> {
-            target.getRootProject().getPlugins().apply(VaultPlugin.class);
-            final VaultExtension vault = target.getRootProject().getExtensions().getByType(VaultExtension.class);
+        final Project rootProject = target.getRootProject();
+        rootProject.getPlugins().withType(BaseCliPlugin.class, unused -> {
+            rootProject.getPlugins().apply(VaultPlugin.class);
+            final VaultExtension vault = rootProject.getRootProject().getExtensions().getByType(VaultExtension.class);
 
-            target.afterEvaluate(t -> {
-                final CliExtension cliExtension = target.getExtensions().getByType(CliExtension.class);
+            rootProject.afterEvaluate(t -> {
+                final CliExtension cliExtension = rootProject.getExtensions().getByType(CliExtension.class);
 
                 var listOfNames = new ArrayList<String>();
                 for (ExtensionsSchema.ExtensionSchema extensionSchema : cliExtension.getExtensions().getExtensionsSchema()) {

--- a/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
+++ b/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
@@ -109,8 +109,11 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
         plugins.withType(VaultPlugin.class, unused ->
                 configureVaultPlugin(target.getExtensions().getByType(VaultExtension.class))
         );
+        target.getRootProject().getPlugins().withType(VaultPlugin.class, unused ->
+                configureVaultPlugin(target.getRootProject().getExtensions().getByType(VaultExtension.class))
+        );
 
-        configureCliPlugins(target, plugins);
+        configureCliPlugins(target);
 
 
 
@@ -138,10 +141,11 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
         });
     }
 
-    private void configureCliPlugins(Project target, PluginContainer plugins) {
-        plugins.withType(BaseCliPlugin.class, unused -> {
-            plugins.apply(VaultPlugin.class);
-            final VaultExtension vault = target.getExtensions().getByType(VaultExtension.class);
+    private void configureCliPlugins(Project target) {
+        // BaseCli project works on the root project, need to configure it there
+        target.getRootProject().getPlugins().withType(BaseCliPlugin.class, unused -> {
+            target.getRootProject().getPlugins().apply(VaultPlugin.class);
+            final VaultExtension vault = target.getRootProject().getExtensions().getByType(VaultExtension.class);
 
             target.afterEvaluate(t -> {
                 final CliExtension cliExtension = target.getExtensions().getByType(CliExtension.class);


### PR DESCRIPTION
Because CLI plugins add configuration to the root project, using the plugin with a multi project build was failing with:
```
* What went wrong:
An exception occurred applying plugin request [id: 'co.elastic.docker-base']
> Failed to apply plugin class 'co.elastic.gradle.cli.base.BaseCliPlugin'.
   > Cannot run Project.afterEvaluate(Action) when the project is already evaluated.
```

This PR fixes the problem by directing the convetnions plugin to also apply configuration to the root project. 
