### PR TITLE
Repo install instruction

### DIFF
--- a/libs/docker/src/main/java/co/elastic/gradle/utils/docker/instruction/RepoConfigInstall.java
+++ b/libs/docker/src/main/java/co/elastic/gradle/utils/docker/instruction/RepoConfigInstall.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.gradle.utils.docker.instruction;
+
+import org.gradle.api.tasks.Input;
+
+import java.util.List;
+
+public record RepoConfigInstall(List<String> packages) implements ContainerImageBuildInstruction {
+    @Input
+    public List<String> getPackages() {
+        return packages;
+    }
+}

--- a/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
+++ b/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
@@ -286,6 +286,7 @@ public class MoreDockerBaseImageBuildPluginIT extends TestkitIntegrationTest {
                 dockerBaseImage {
                     osPackageRepository.set(URL("https://${creds["username"]}:${creds["plaintext"]}@artifactory.elastic.dev/artifactory/gradle-plugins-os-packages"))
                     fromCentos("centos", "7")
+                    repoInstall("epel-release")
                     repoConfig("yum -y install epel-release")
                     install("jq")
                     run("jq --version")

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
@@ -117,12 +117,14 @@ public abstract class BaseImageExtension implements ExtensionAware {
     public void fromUbuntu(String image, String version) {
         getOSDistribution().set(OSDistribution.UBUNTU);
         from(image, version);
+        env(new Pair<>("DEBIAN_FRONTEND", "noninteractive"));
     }
 
     @SuppressWarnings("unused")
     public void fromDebian(String image, String version) {
         getOSDistribution().set(OSDistribution.DEBIAN);
         from(image, version);
+        env(new Pair<>("DEBIAN_FRONTEND", "noninteractive"));
     }
 
     @SuppressWarnings("unused")

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
@@ -167,6 +167,15 @@ public abstract class BaseImageExtension implements ExtensionAware {
         repoConfig(Arrays.asList(commands));
     }
 
+    public void repoInstall(List<String> packages) {
+        instructions.add(new RepoConfigInstall(packages));
+    }
+
+    @SuppressWarnings("unused")
+    public void repoInstall(String... packages) {
+        repoInstall(Arrays.asList(packages));
+    }
+
     @SuppressWarnings("unused")
     public void createUser(String username, Integer userId, String group, Integer groupId) {
         instructions.add(new CreateUser(username, group, userId, groupId));

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
@@ -172,14 +172,19 @@ public abstract class DockerDaemonActions {
                     }).collect(Collectors.joining(" "));
             return "RUN " + mountOptions + "\\\n " +
                    String.join(" && \\ \n\t", run.getCommands());
-        } else if (instruction instanceof RepoConfigRun repoConfig) {
+        } else if (instruction instanceof RepoConfigRun repoConfigRun) {
             if (buildable.getIsolateFromExternalRepos().get()) {
                 return "";
             } else {
-                return "RUN " + String.join(" && \\ \n\t", repoConfig.getCommands());
+                return "RUN " + String.join(" && \\ \n\t", repoConfigRun.getCommands());
             }
-        }
-        else if (instruction instanceof CreateUser createUser) {
+        } else if (instruction instanceof RepoConfigInstall repoConfigInstall) {
+            if (buildable.getIsolateFromExternalRepos().get()) {
+                return "";
+            } else {
+                return convertInstallToRun(new Install(repoConfigInstall.packages())).map(this::instructionAsDockerFileInstruction).findAny().orElse("");
+            }
+        } else if (instruction instanceof CreateUser createUser) {
             // Specific case for Alpine and Busybox
             return String.format(
                     """


### PR DESCRIPTION
This PR adds a new instruction called `repoInstall`. It behaves similar to `repoConfig` in that it only executes during the lockfile generation phase, but beside the condition the output is the same as `install`.

This allows for the installation of dependencies that are required to add a repository (e.g. `software-properties-common`), or packages that themselves install a repository (e.g. `epel-release`).

It also sets `DEBIAN_FRONTEND=noninteractive` by default for Ubuntu and Debian images to prevent package installations from asking for input.