### PR TITLE
Repo install instruction

### DIFF
--- a/libs/docker/src/main/java/co/elastic/gradle/utils/docker/instruction/RepoConfigInstall.java
+++ b/libs/docker/src/main/java/co/elastic/gradle/utils/docker/instruction/RepoConfigInstall.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.gradle.utils.docker.instruction;
+
+import org.gradle.api.tasks.Input;
+
+import java.util.List;
+
+public record RepoConfigInstall(List<String> packages) implements ContainerImageBuildInstruction {
+    @Input
+    public List<String> getPackages() {
+        return packages;
+    }
+}

--- a/libs/docker/src/main/java/co/elastic/gradle/utils/docker/instruction/RepoInstall.java
+++ b/libs/docker/src/main/java/co/elastic/gradle/utils/docker/instruction/RepoInstall.java
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.Input;
 
 import java.util.List;
 
-public record RepoConfigInstall(List<String> packages) implements ContainerImageBuildInstruction {
+public record RepoInstall(List<String> packages) implements ContainerImageBuildInstruction {
     @Input
     public List<String> getPackages() {
         return packages;

--- a/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
+++ b/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
@@ -286,6 +286,7 @@ public class MoreDockerBaseImageBuildPluginIT extends TestkitIntegrationTest {
                 dockerBaseImage {
                     osPackageRepository.set(URL("https://${creds["username"]}:${creds["plaintext"]}@artifactory.elastic.dev/artifactory/gradle-plugins-os-packages"))
                     fromCentos("centos", "7")
+                    repoInstall("epel-release")
                     repoConfig("yum -y install epel-release")
                     install("jq")
                     run("jq --version")

--- a/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
+++ b/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
@@ -19,6 +19,7 @@
 package co.elastic.gradle.dockerbase;
 
 import co.elastic.gradle.TestkitIntegrationTest;
+import co.elastic.gradle.dockerbase.lockfile.BaseLockfile;
 import co.elastic.gradle.sandbox.SandboxDockerExecTask;
 import co.elastic.gradle.utils.Architecture;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,6 +41,8 @@ import java.util.List;
 import java.util.Objects;
 
 import static co.elastic.gradle.AssertContains.assertContains;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class MoreDockerBaseImageBuildPluginIT extends TestkitIntegrationTest {
@@ -286,7 +289,6 @@ public class MoreDockerBaseImageBuildPluginIT extends TestkitIntegrationTest {
                 dockerBaseImage {
                     osPackageRepository.set(URL("https://${creds["username"]}:${creds["plaintext"]}@artifactory.elastic.dev/artifactory/gradle-plugins-os-packages"))
                     fromCentos("centos", "7")
-                    repoInstall("epel-release")
                     repoConfig("yum -y install epel-release")
                     install("jq")
                     run("jq --version")
@@ -303,6 +305,56 @@ public class MoreDockerBaseImageBuildPluginIT extends TestkitIntegrationTest {
                 "dockerBaseImageBuild"
         ).build();
 
+    }
+
+    @Test
+    public void testRepoInstall() throws IOException {
+        helper.buildScript("""
+                import java.net.URL
+                plugins {
+                   id("co.elastic.docker-base")
+                   id("co.elastic.vault")
+                }
+                vault {
+                      address.set("https://vault-ci-prod.elastic.dev")
+                      auth {
+                        ghTokenFile()
+                        ghTokenEnv()
+                        tokenEnv()
+                        roleAndSecretEnv()
+                      }
+                }
+                val creds = vault.readAndCacheSecret("secret/ci/elastic-gradle-plugins/artifactory_creds").get()
+                dockerBaseImage {
+                    osPackageRepository.set(URL("https://${creds["username"]}:${creds["plaintext"]}@artifactory.elastic.dev/artifactory/gradle-plugins-os-packages"))
+                    fromUbuntu("ubuntu", "20.04")
+                    repoInstall("software-properties-common")
+                    repoConfig("add-apt-repository ppa:vbernat/haproxy-2.8")
+                    install("haproxy")
+                }
+                """
+        );
+
+        final BuildResult Lockfileresult = gradleRunner.withArguments("--warning-mode", "fail", "-s",
+                "dockerBaseImageLockfile"
+        ).build();
+        System.out.println(Lockfileresult.getOutput());
+
+        // software-properties-common should be mentioned in the dockerBaseImageLockfile Dockerfile
+        final Path lockDockerfilePath = helper.projectDir().resolve("build/dockerBaseImageLockfile/Dockerfile");
+        assertContains(Files.readString(lockDockerfilePath), "software-properties-common");
+
+        // software-properties-common should not be in the lockfile
+        BaseLockfile lockfile = BaseLockfile.parse(Files.newBufferedReader(helper.projectDir().resolve("docker-base-image.lock")));
+        assertFalse(lockfile.getPackages().get(Architecture.current()).findByName("software-properties-common").isPresent());
+
+        final BuildResult result = gradleRunner.withArguments("--warning-mode", "fail", "-s",
+                "dockerBaseImageBuild"
+        ).build();
+
+        // software-properties-common should not be mentioned in the dockerBaseImageBuild Dockerfile
+        final Path buildDockerfilePath = helper.projectDir().resolve("build/dockerBaseImageBuild/Dockerfile");
+        assertContains(Files.readString(buildDockerfilePath), "software-properties-common");
     }
 
     @Test

--- a/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
+++ b/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static co.elastic.gradle.AssertContains.assertContains;
+import static co.elastic.gradle.AssertContains.assertDoesNotContain;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -354,7 +355,7 @@ public class MoreDockerBaseImageBuildPluginIT extends TestkitIntegrationTest {
 
         // software-properties-common should not be mentioned in the dockerBaseImageBuild Dockerfile
         final Path buildDockerfilePath = helper.projectDir().resolve("build/dockerBaseImageBuild/Dockerfile");
-        assertContains(Files.readString(buildDockerfilePath), "software-properties-common");
+        assertDoesNotContain(Files.readString(buildDockerfilePath), "software-properties-common");
     }
 
     @Test

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
@@ -117,12 +117,14 @@ public abstract class BaseImageExtension implements ExtensionAware {
     public void fromUbuntu(String image, String version) {
         getOSDistribution().set(OSDistribution.UBUNTU);
         from(image, version);
+        env(new Pair<>("DEBIAN_FRONTEND", "noninteractive"));
     }
 
     @SuppressWarnings("unused")
     public void fromDebian(String image, String version) {
         getOSDistribution().set(OSDistribution.DEBIAN);
         from(image, version);
+        env(new Pair<>("DEBIAN_FRONTEND", "noninteractive"));
     }
 
     @SuppressWarnings("unused")

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
@@ -167,6 +167,15 @@ public abstract class BaseImageExtension implements ExtensionAware {
         repoConfig(Arrays.asList(commands));
     }
 
+    public void repoInstall(List<String> packages) {
+        instructions.add(new RepoConfigInstall(packages));
+    }
+
+    @SuppressWarnings("unused")
+    public void repoInstall(String... packages) {
+        repoInstall(Arrays.asList(packages));
+    }
+
     @SuppressWarnings("unused")
     public void createUser(String username, Integer userId, String group, Integer groupId) {
         instructions.add(new CreateUser(username, group, userId, groupId));

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/BaseImageExtension.java
@@ -170,7 +170,7 @@ public abstract class BaseImageExtension implements ExtensionAware {
     }
 
     public void repoInstall(List<String> packages) {
-        instructions.add(new RepoConfigInstall(packages));
+        instructions.add(new RepoInstall(packages));
     }
 
     @SuppressWarnings("unused")

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
@@ -172,14 +172,19 @@ public abstract class DockerDaemonActions {
                     }).collect(Collectors.joining(" "));
             return "RUN " + mountOptions + "\\\n " +
                    String.join(" && \\ \n\t", run.getCommands());
-        } else if (instruction instanceof RepoConfigRun repoConfig) {
+        } else if (instruction instanceof RepoConfigRun repoConfigRun) {
             if (buildable.getIsolateFromExternalRepos().get()) {
                 return "";
             } else {
-                return "RUN " + String.join(" && \\ \n\t", repoConfig.getCommands());
+                return "RUN " + String.join(" && \\ \n\t", repoConfigRun.getCommands());
             }
-        }
-        else if (instruction instanceof CreateUser createUser) {
+        } else if (instruction instanceof RepoConfigInstall repoConfigInstall) {
+            if (buildable.getIsolateFromExternalRepos().get()) {
+                return "";
+            } else {
+                return convertInstallToRun(new Install(repoConfigInstall.packages())).map(this::instructionAsDockerFileInstruction).findAny().orElse("");
+            }
+        } else if (instruction instanceof CreateUser createUser) {
             // Specific case for Alpine and Busybox
             return String.format(
                     """

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
@@ -182,7 +182,7 @@ public abstract class DockerDaemonActions {
             if (buildable.getIsolateFromExternalRepos().get()) {
                 return "";
             } else {
-                return convertInstallToRun(new Install(repoInstall.packages())).map(this::instructionAsDockerFileInstruction).findAny().orElse("");
+                return convertInstallToRun(new Install(repoInstall.packages())).map(this::instructionAsDockerFileInstruction).collect(Collectors.joining("\n"));
             }
         } else if (instruction instanceof CreateUser createUser) {
             // Specific case for Alpine and Busybox

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
@@ -178,11 +178,11 @@ public abstract class DockerDaemonActions {
             } else {
                 return "RUN " + String.join(" && \\ \n\t", repoConfigRun.getCommands());
             }
-        } else if (instruction instanceof RepoConfigInstall repoConfigInstall) {
+        } else if (instruction instanceof RepoInstall repoInstall) {
             if (buildable.getIsolateFromExternalRepos().get()) {
                 return "";
             } else {
-                return convertInstallToRun(new Install(repoConfigInstall.packages())).map(this::instructionAsDockerFileInstruction).findAny().orElse("");
+                return convertInstallToRun(new Install(repoInstall.packages())).map(this::instructionAsDockerFileInstruction).findAny().orElse("");
             }
         } else if (instruction instanceof CreateUser createUser) {
             // Specific case for Alpine and Busybox

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
@@ -29,9 +29,7 @@ import co.elastic.gradle.utils.RetryUtils;
 import co.elastic.gradle.utils.docker.DockerPluginConventions;
 import co.elastic.gradle.utils.docker.DockerUtils;
 import co.elastic.gradle.utils.docker.UnchangingContainerReference;
-import co.elastic.gradle.utils.docker.instruction.ContainerImageBuildInstruction;
-import co.elastic.gradle.utils.docker.instruction.From;
-import co.elastic.gradle.utils.docker.instruction.SetUser;
+import co.elastic.gradle.utils.docker.instruction.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.csv.CSVFormat;
@@ -60,6 +58,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class DockerLockfileTask extends DefaultTask implements ImageBuildable, JFrogCliUsingTask {
@@ -157,15 +156,30 @@ public abstract class DockerLockfileTask extends DefaultTask implements ImageBui
                                         return instruction;
                                     }
                                 }),
-                        Stream.of(
-                                new SetUser("root"),
-                                DockerDaemonActions.wrapInstallCommand(
-                                        this,
-                                        switch (getOSDistribution().get()) {
-                                            case UBUNTU, DEBIAN -> "apt-get -y --allow-unauthenticated upgrade";
-                                            case CENTOS -> "yum -y upgrade";
-                                        }
-                                )
+                        Stream.concat(
+                            getInputInstructions().get().stream().flatMap(i -> {
+                                if (i instanceof RepoInstall repoInstall) {
+                                    final String packages = repoInstall.getPackages().stream().collect(Collectors.joining(" "));
+                                    return Stream.of(
+                                            new SetUser("root"),
+                                            switch (getOSDistribution().get()) {
+                                                case UBUNTU, DEBIAN -> new Run(List.of("apt-get -y --auto-remove purge " + packages));
+                                                case CENTOS -> new Run(List.of("yum -y --remove-leaves remove " + packages));
+                                            }
+                                    );
+                                }
+                                return Stream.empty();
+                            }),
+                            Stream.of(
+                                    new SetUser("root"),
+                                    DockerDaemonActions.wrapInstallCommand(
+                                            this,
+                                            switch (getOSDistribution().get()) {
+                                                case UBUNTU, DEBIAN -> "apt-get -y --allow-unauthenticated upgrade";
+                                                case CENTOS -> "yum -y upgrade";
+                                            }
+                                    )
+                            )
                         )
                 )
                 .toList();

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
@@ -163,7 +163,7 @@ public abstract class DockerLockfileTask extends DefaultTask implements ImageBui
                                     return Stream.of(
                                             new SetUser("root"),
                                             switch (getOSDistribution().get()) {
-                                                case UBUNTU, DEBIAN -> new Run(List.of("apt-get -y purge " + packages, "apt-get -y autoremove"));
+                                                case UBUNTU, DEBIAN -> new Run(List.of("apt-get -y --auto-remove purge " + packages));
                                                 case CENTOS -> new Run(List.of("yum -y --remove-leaves remove " + packages));
                                             }
                                     );

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
@@ -163,7 +163,7 @@ public abstract class DockerLockfileTask extends DefaultTask implements ImageBui
                                     return Stream.of(
                                             new SetUser("root"),
                                             switch (getOSDistribution().get()) {
-                                                case UBUNTU, DEBIAN -> new Run(List.of("apt-get -y --auto-remove purge " + packages));
+                                                case UBUNTU, DEBIAN -> new Run(List.of("apt-get -y purge " + packages, "apt-get -y autoremove"));
                                                 case CENTOS -> new Run(List.of("yum -y --remove-leaves remove " + packages));
                                             }
                                     );


### PR DESCRIPTION
This PR adds a new instruction called `repoInstall`. It behaves similar to `repoConfig` in that it only executes during the lockfile generation phase, but beside the condition the output is the same as `install`.

This allows for the installation of dependencies that are required to add a repository (e.g. `software-properties-common`), or packages that themselves install a repository (e.g. `epel-release`).

It also sets `DEBIAN_FRONTEND=noninteractive` by default for Ubuntu and Debian images to prevent package installations from asking for input.