### PR TITLE
Mandatory vault prefix configuration

### DIFF
--- a/libs/test-utils/src/main/java/co/elastic/gradle/TestkitIntegrationTest.java
+++ b/libs/test-utils/src/main/java/co/elastic/gradle/TestkitIntegrationTest.java
@@ -37,7 +37,7 @@ public class TestkitIntegrationTest {
         helper = getHelper(testProjectDir);
         // Each suite needs to get its own tes-kit dir as running many tests in parallel causes locking issues on the
         // local artifactory cache. This does create multiple copies of the artefact cache to be used by the tests.
-        testkitDir = Path.of(System.getProperty("java.io.tmpdir") + this.getClass().getName());
+        testkitDir = Path.of(System.getProperty("java.io.tmpdir")).resolve(this.getClass().getName());
         Files.createDirectories(testkitDir);
         gradleRunner = getGradleRunner(testProjectDir);
     }

--- a/libs/test-utils/src/main/java/co/elastic/gradle/TestkitIntegrationTest.java
+++ b/libs/test-utils/src/main/java/co/elastic/gradle/TestkitIntegrationTest.java
@@ -30,16 +30,22 @@ public class TestkitIntegrationTest {
 
     protected GradleTestkitHelper helper;
     protected GradleRunner gradleRunner;
+    protected Path testkitDir;
 
     @BeforeEach
     void setUp(@TempDir Path testProjectDir) throws IOException {
         helper = getHelper(testProjectDir);
+        // Each suite needs to get its own tes-kit dir as running many tests in parallel causes locking issues on the
+        // local artifactory cache. This does create multiple copies of the artefact cache to be used by the tests.
+        testkitDir = Path.of(System.getProperty("java.io.tmpdir") + this.getClass().getName());
+        Files.createDirectories(testkitDir);
         gradleRunner = getGradleRunner(testProjectDir);
     }
 
     protected GradleRunner getGradleRunner(Path testProjectDir) {
         final GradleRunner gradleRunner = GradleRunner.create()
                 .withProjectDir(testProjectDir.toFile())
+                .withTestKitDir(testkitDir.toFile())
                 .withPluginClasspath();
         return gradleRunner;
     }

--- a/plugins/cli/build.gradle.kts
+++ b/plugins/cli/build.gradle.kts
@@ -1,0 +1,7 @@
+subprojects {
+    tasks.integrationTest {
+        // Need to validate these on a per OS and architecture basis
+        inputs.properties("OS" to co.elastic.gradle.utils.OS.current())
+        inputs.properties("Architecture" to co.elastic.gradle.utils.Architecture.current())
+    }
+}

--- a/plugins/cli/cli-lib/src/main/java/co/elastic/gradle/cli/base/MultipleSymlinkTask.java
+++ b/plugins/cli/cli-lib/src/main/java/co/elastic/gradle/cli/base/MultipleSymlinkTask.java
@@ -116,7 +116,12 @@ public abstract class MultipleSymlinkTask extends DefaultTask {
                         return nameHasCurrentOS;
                     } else {
                         // When the name has no architecture, we imply x86_64
-                        return nameHasCurrentOS && arch.equals(Architecture.X86_64);
+                        if (OS.current().equals(OS.DARWIN)) {
+                            // except for mac where some binaries still rely on emulation
+                            return nameHasCurrentOS;
+                        } else {
+                            return nameHasCurrentOS && arch.equals(Architecture.X86_64);
+                        }
                     }
                 })
                 .collect(Collectors.toMap(
@@ -125,8 +130,8 @@ public abstract class MultipleSymlinkTask extends DefaultTask {
                             for (OS os : OS.values()) {
                                 for (String separator : List.of("-", ".")) {
                                     name = name
-                                            .replace(separator + OS.current().name(), "")
-                                            .replace(separator + OS.current().name().toLowerCase(Locale.ROOT), "")
+                                            .replace(separator + os.name(), "")
+                                            .replace(separator + os.name().toLowerCase(Locale.ROOT), "")
                                             .replace(separator + arch.name(), "")
                                             .replace(separator + arch.name().toLowerCase(Locale.ROOT), "")
                                             .replace(separator + arch.dockerName(), "")

--- a/plugins/docker/base-image/build.gradle.kts
+++ b/plugins/docker/base-image/build.gradle.kts
@@ -42,3 +42,9 @@ dependencies {
     integrationTestImplementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     integrationTestImplementation(project(":libs:utils"))
 }
+
+tasks.integrationTest {
+    // Need to validate these on a per OS and architecture basis
+    inputs.properties("OS" to co.elastic.gradle.utils.OS.current())
+    inputs.properties("Architecture" to co.elastic.gradle.utils.Architecture.current())
+}

--- a/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
+++ b/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/MoreDockerBaseImageBuildPluginIT.java
@@ -132,6 +132,12 @@ public class MoreDockerBaseImageBuildPluginIT extends TestkitIntegrationTest {
                     mavenCentral()
                 }
                 val creds = vault.readAndCacheSecret("secret/ci/elastic-gradle-plugins/artifactory_creds").get()
+                cli {
+                    jfrog {
+                        username.set(creds["username"])
+                        password.set(creds["plaintext"])
+                    }
+                }
                 dockerBaseImage {
                     osPackageRepository.set(URL("https://${creds["username"]}:${creds["plaintext"]}@artifactory.elastic.dev/artifactory/gradle-plugins-os-packages"))
                     fromUbuntu("ubuntu", "20.04")

--- a/plugins/elastic-conventions/build.gradle.kts
+++ b/plugins/elastic-conventions/build.gradle.kts
@@ -35,3 +35,9 @@ dependencies {
     integrationTestImplementation(project(":plugins:cli:snyk"))
     integrationTestImplementation(project(":plugins:cli:manifest-tool"))
 }
+
+tasks.integrationTest {
+    // Need to validate these on a per OS and architecture basis
+    inputs.properties("OS" to co.elastic.gradle.utils.OS.current())
+    inputs.properties("Architecture" to co.elastic.gradle.utils.Architecture.current())
+}

--- a/plugins/elastic-conventions/src/integrationTest/java/co/elastic/gradle/elatic_conventions/ElasticConventionsPluginIT.java
+++ b/plugins/elastic-conventions/src/integrationTest/java/co/elastic/gradle/elatic_conventions/ElasticConventionsPluginIT.java
@@ -110,11 +110,11 @@ public class ElasticConventionsPluginIT extends TestkitIntegrationTest {
                       dependsOn(jfrog, manifestTool)
                    }
                  
-                """, JFrogCliExecTask.class.getName(), ManifestToolExecTask.class.getName(), getVaultPrefixProperty())
+                """, JFrogCliExecTask.class.getName(), ManifestToolExecTask.class.getName())
         );
 
         final BuildResult result = gradleRunner
-                .withArguments("--warning-mode", "fail", "-s", "check", "--refresh-dependencies", "")
+                .withArguments("--warning-mode", "fail", "-s", "check", "--refresh-dependencies", getVaultPrefixProperty())
                 .build();
 
         System.out.println(result.getOutput());
@@ -155,7 +155,7 @@ public class ElasticConventionsPluginIT extends TestkitIntegrationTest {
                 .buildAndFail();
 
         assertContains(result.getOutput(),
-                "This plugin requires the co.elastic.vault_prefix to be set for the vault integration." +
+                "This plugin requires the co.elastic.vault_prefix to be set for the vault integration. " +
                 "Most of the time this needs to be set in the gradle.properties in your repo to `secret/ci/elastic-<name of your repo>`."
         );
     }

--- a/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
+++ b/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
@@ -70,7 +70,7 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
     private String getVaultPrefix(Project target) {
         final Object vaultPrefixFromProperty = target.getProperties().get(PROPERTY_NAME_VAULT_PREFIX);
         if (vaultPrefixFromProperty == null) {
-            throw new GradleException("This plugin requires the co.elastic.vault_prefix to be set for the vault integration." +
+            throw new GradleException("This plugin requires the co.elastic.vault_prefix to be set for the vault integration. " +
                                       "Most of the time this needs to be set in the gradle.properties in your repo to `secret/ci/elastic-<name of your repo>`.");
         }
         return vaultPrefixFromProperty.toString();

--- a/plugins/sandbox/build.gradle.kts
+++ b/plugins/sandbox/build.gradle.kts
@@ -15,3 +15,9 @@ dependencies {
     implementation(project(":libs:utils"))
     implementation(project(":plugins:lifecycle"))
 }
+
+tasks.integrationTest {
+    // Need to validate these on a per OS and architecture basis
+    inputs.properties("OS" to co.elastic.gradle.utils.OS.current())
+    inputs.properties("Architecture" to co.elastic.gradle.utils.Architecture.current())
+}

--- a/plugins/wrapper-provision-jdk/build.gradle.kts
+++ b/plugins/wrapper-provision-jdk/build.gradle.kts
@@ -15,3 +15,9 @@ dependencies {
     integrationTestImplementation(project(":libs:utils"))
     integrationTestImplementation("commons-io:commons-io:2.11.0")
 }
+
+tasks.integrationTest {
+    // Need to validate these on a per OS and architecture basis
+    inputs.properties("OS" to co.elastic.gradle.utils.OS.current())
+    inputs.properties("Architecture" to co.elastic.gradle.utils.Architecture.current())
+}


### PR DESCRIPTION
**Switch from vault prefix based on repo to mandatory property**

The previous repo based auto config was problematic in some contexts where the repo information was last and it's also causing issues with local development. 

**Fix cli plugin on mac**

As part of working on this saw and fixed some tests failing on MAC. We don't run on macs in CI so this went unnoticed. 
