### PR TITLE
Add test and fix component image resolve dependencies

### DIFF
--- a/plugins/docker/component-image/src/main/java/co/elastic/gradle/dockercomponent/ComponentPullTask.java
+++ b/plugins/docker/component-image/src/main/java/co/elastic/gradle/dockercomponent/ComponentPullTask.java
@@ -22,7 +22,7 @@ import co.elastic.gradle.dockercomponent.lockfile.ComponentLockfile;
 import co.elastic.gradle.utils.RegularFileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.api.tasks.TaskAction;
 
@@ -32,7 +32,7 @@ import java.nio.file.Path;
 
 public abstract class ComponentPullTask extends DefaultTask {
 
-    @InputFile
+    @InputFiles
     public abstract RegularFileProperty getLockfileLocation();
 
     @TaskAction

--- a/plugins/docker/component-image/src/main/java/co/elastic/gradle/dockercomponent/ComponentPullTask.java
+++ b/plugins/docker/component-image/src/main/java/co/elastic/gradle/dockercomponent/ComponentPullTask.java
@@ -22,8 +22,8 @@ import co.elastic.gradle.dockercomponent.lockfile.ComponentLockfile;
 import co.elastic.gradle.utils.RegularFileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.IOException;
@@ -32,13 +32,15 @@ import java.nio.file.Path;
 
 public abstract class ComponentPullTask extends DefaultTask {
 
-    @InputFiles
-    @SkipWhenEmpty
+    @InputFile
     public abstract RegularFileProperty getLockfileLocation();
 
     @TaskAction
     public void pullImages() throws IOException {
         final Path lockfileLocation = RegularFileUtils.toPath(getLockfileLocation());
+        if (!Files.exists(lockfileLocation)) {
+            throw new StopExecutionException("Lockfile does not exist");
+        }
         final ComponentLockfile lockFile = ComponentLockfile.parse(Files.newBufferedReader(lockfileLocation));
         final JibActions actions = new JibActions();
         lockFile.images().values().forEach(ref -> {

--- a/plugins/elastic-conventions/src/integrationTest/java/co/elastic/gradle/elatic_conventions/ElasticConventionsPluginIT.java
+++ b/plugins/elastic-conventions/src/integrationTest/java/co/elastic/gradle/elatic_conventions/ElasticConventionsPluginIT.java
@@ -329,6 +329,8 @@ public class ElasticConventionsPluginIT extends TestkitIntegrationTest {
                 .buildAndFail();
 
         assertContains(scanResult.getOutput(), "[snyk] Tested ");
+
+        gradleRunner.withArguments("--warning-mode", "fail", "-S", "resolveAllDependencies", getVaultPrefixProperty()).build();
     }
 
     @Test
@@ -360,6 +362,8 @@ public class ElasticConventionsPluginIT extends TestkitIntegrationTest {
                 .buildAndFail();
 
         assertContains(scanResult.getOutput(), "[snyk] Tested ");
+
+        gradleRunner.withArguments("--warning-mode", "fail", "-S", "resolveAllDependencies", getVaultPrefixProperty()).build();
     }
 
 }


### PR DESCRIPTION
Fixes https://elasticco.atlassian.net/browse/DEV-348 (internal link).

Calling `resolveAllDependencies` failed because `ComponentPullTask` was not being skipped as it was supposed to. 
The reson for that is that `@SkipWhenEmpty` only works with `FileCollection`a and we had a single file in this case. 

This PR adds a test and implement the intended behavior.
