### PR TITLE
Suppress noisy curl output in `archive_apk_packages`

### DIFF
--- a/plugins/docker/base-image/src/main/resources/archive-packages.sh
+++ b/plugins/docker/base-image/src/main/resources/archive-packages.sh
@@ -126,7 +126,7 @@ archive_apk_packages() {
   for URL in $URLS; do
       FILENAME=$(basename "$URL")
       echo "Downloading: $URL" >&2
-      curl -q -o "/var/cache/apk/archives/$PACKAGES_ARCH/$FILENAME" "$URL" >&2
+      curl --silent -o "/var/cache/apk/archives/$PACKAGES_ARCH/$FILENAME" "$URL" >&2
   done
   if [ "$KEEP_CURL" == 'no' ] ; then
       echo "Removing curl so it's not part of the image" >&2


### PR DESCRIPTION
curl was called with the `-q` parameter which I assume was meant to suppress download progress output (similar to how wget supports `-q/--quiet`). However in curl the `-q` option does something completely different (see https://curl.se/docs/manpage.html#-q). The correct option in curl is `-s/--silent`.