### PR TITLE
Fix cross-platform docker lock file generation

### DIFF
--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
@@ -178,7 +178,7 @@ public abstract class DockerLockfileTask extends DefaultTask implements ImageBui
                                             switch (getOSDistribution().get()) {
                                                 case UBUNTU, DEBIAN -> "apt-get -y --allow-unauthenticated upgrade";
                                                 case CENTOS -> "yum -y upgrade";
-                                                case WOLFI -> "apk upgrade --nocache";
+                                                case WOLFI -> "apk upgrade --no-cache";
                                             }
                                     )
                             )

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerLockfileTask.java
@@ -178,7 +178,7 @@ public abstract class DockerLockfileTask extends DefaultTask implements ImageBui
                                             switch (getOSDistribution().get()) {
                                                 case UBUNTU, DEBIAN -> "apt-get -y --allow-unauthenticated upgrade";
                                                 case CENTOS -> "yum -y upgrade";
-                                                case WOLFI -> "apk upgrade";
+                                                case WOLFI -> "apk upgrade --nocache";
                                             }
                                     )
                             )


### PR DESCRIPTION
The `apk upgrade` command in the `dockerBaseImageLockfileamd64` task would fail on a ARM64 machine (in emulation mode) with
```
#11 [stage-0 7/7] RUN --mount=type=bind,readonly,target=/mnt/ephemeral,source=ephemeral/docker apk upgrade
#11 0.128 fetch https://packages.cgr.dev/extras/x86_64/APKINDEX.tar.gz
#11 0.373 WARNING: opening from cache https://packages.cgr.dev/extras: No such file or directory
#11 0.373 fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
#11 0.588 WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory
#11 0.588 ERROR: Not continuing due to stale/unavailable repositories.Use --force-missing-repositories to continue.
#11 ERROR: process "/bin/sh -c apk upgrade" did not complete successfully: exit code: 99
```

Adding the `--no-cache` parameter solves this, similar to #46.