### PR TITLE
chore(renovate): group Gradle Enterprise plugin dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>elastic/renovate-config:platform-devflow"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Gradle Enterprise Plugin",
+      "matchDepNames": [
+        "com.gradle.enterprise",
+        "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
So we make sure we're always using the same version for our own build as
well as the version we're using for consumers.

Off the back of https://github.com/elastic/gradle-plugins/pull/78#pullrequestreview-2250463432
