### PR TITLE
allow users to supply a sha in their tags

### DIFF
--- a/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/DockerBaseImageMatrix.java
+++ b/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/DockerBaseImageMatrix.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class DockerBaseImageMatrix extends TestkitIntegrationTest  {
 
     @ParameterizedTest
-    @ValueSource(strings = {"docker.elastic.co/wolfi/chainguard-base:latest", "ubuntu:20.04", "ubuntu:22.04", "debian:11"})
+    @ValueSource(strings = {"docker.elastic.co/wolfi/chainguard-base:latest@sha256:c16d3ad6cebf387e8dd2ad769f54320c4819fbbaa21e729fad087c7ae223b4d0", "ubuntu:20.04", "ubuntu:22.04", "debian:11"})
     // Todo Temp disabled. fix centos base image plugin builds
     // @ValueSource(strings = {"ubuntu:20.04", "ubuntu:22.04", "centos:7", "debian:11"})
     public void testSingleProject(String baseImages, @TempDir Path gradleHome) throws IOException, InterruptedException {
@@ -101,8 +101,7 @@ public class DockerBaseImageMatrix extends TestkitIntegrationTest  {
     }
 
     private void writeSimpleBuildScript(GradleTestkitHelper helper, String baseImages) {
-        final String[] from = baseImages.split(":");
-        assertEquals(2, from.length);
+        final String[] from = baseImages.split(":", 2);
         final String fromType;
         if (baseImages.contains("chainguard")) {
             fromType = "Wolfi";

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerBaseImageBuildTask.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerBaseImageBuildTask.java
@@ -140,12 +140,6 @@ public abstract class DockerBaseImageBuildTask extends DefaultTask implements Im
                                     throw new GradleException("Missing image in lockfile, does it need to be regenerated?");
                                 }
                                 UnchangingContainerReference lockedImage = lockfile.getImage().get(Architecture.current());
-                                if (from.getReference().get().contains("@")) {
-                                    throw new IllegalStateException(
-                                            "The sha should come from the lockfile and thus should " +
-                                            "not be specified in the input instructions."
-                                    );
-                                }
                                 if (!from.getReference().get().contains(lockedImage.getRepository()) ||
                                     !from.getReference().get().contains(lockedImage.getTag())
                                 ) {


### PR DESCRIPTION
Allows users to supply a digest with their tags.  First part of https://elasticco.atlassian.net/browse/DEV-530

Next we need to publish, bump cloud, then adjust renovate-config/base.json to update `fromWofli, fromUbuntu` etc statements like its configured to bump `from` statements in the old plugins.