### PR TITLE
Fix implied dependency between emulated and non emualted base image builds

### DIFF
--- a/libs/docker/src/main/java/co/elastic/gradle/utils/docker/instruction/FromLocalImageBuild.java
+++ b/libs/docker/src/main/java/co/elastic/gradle/utils/docker/instruction/FromLocalImageBuild.java
@@ -18,19 +18,28 @@
  */
 package co.elastic.gradle.utils.docker.instruction;
 
+import co.elastic.gradle.utils.Architecture;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 
 public record FromLocalImageBuild(String otherProjectPath,
                                   Provider<String> tag,
-                                  Provider<String> imageId)
-        implements FromImageReference {
+                                  Provider<String> imageId,
+                                  Architecture architecture
+    ) implements FromImageReference {
+
 
     @Input
     public Provider<String> getImageId() {
         return imageId;
     }
+
+    @Internal
+    // This is a quick fix to add this here and be able to filter based on it.
+    // Ideally now that we added emulation in a number of places, we should have a Map<Architecture, List<Instruction>>
+    // for the base plugin, similar to the component plugin
+    public Architecture getArchitecture() { return architecture ;}
 
     @Override
     @Internal

--- a/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
+++ b/plugins/docker/base-image/src/main/java/co/elastic/gradle/dockerbase/DockerDaemonActions.java
@@ -135,7 +135,7 @@ public abstract class DockerDaemonActions {
                                           "mkdir '" + archDir + "' && " +
                                           "mv *.apk '" + archDir + "' &&" +
                                           "mv __META__Packages* '" + archDir + "/APKINDEX.tar.gz' &&" +
-                                          "apk update --allow-untrusted && find /var/packages-from-gradle").filter(s -> requiresCleanLayers),
+                                          "apk update --allow-untrusted").filter(s -> requiresCleanLayers),
                                 // When building the lock-file we do NOT allow untrusted sources
                                 Stream.of(command.replace("apk add", "apk add --no-cache")).filter(s -> !requiresCleanLayers),
                                 // When we're building the actual image, everything is coming from Gradle, so it's safe
@@ -178,7 +178,7 @@ public abstract class DockerDaemonActions {
         if (instruction instanceof From from) {
             return "FROM " + from.getReference().get();
         } else if (instruction instanceof final FromLocalImageBuild fromLocalImageBuild) {
-            return "# " + fromLocalImageBuild.otherProjectPath() + "\n" +
+            return "# " + fromLocalImageBuild.otherProjectPath() + " (" + fromLocalImageBuild.getArchitecture() +")\n" +
                    "FROM " + fromLocalImageBuild.tag().get();
         } else if (instruction instanceof Copy copySpec) {
             return "COPY " + Optional.ofNullable(copySpec.getOwner()).map(s -> "--chown=" + s + " ").orElse("") +
@@ -330,7 +330,7 @@ public abstract class DockerDaemonActions {
                     .filter(each -> each instanceof FromImageReference)
                     .map(each -> ((FromImageReference) each).getReference().get())
                     .findFirst()
-                    .orElseThrow(() -> new GradleException("A base image is not configured"));
+                    .orElseThrow(() -> new GradleException("A base image is not configured "));
             final ByteArrayOutputStream whoAmIOut = new ByteArrayOutputStream();
             dockerUtils.exec(execSpec -> {
                 execSpec.setStandardOutput(whoAmIOut);


### PR DESCRIPTION
This was a tricky one. The tasks dependencies were mangled because of Gradle implied dependencies when using providers. 
The base image build tasks were implied dependencies because they were going trough providers trough the list of instructions. 

As part of working on this I also noticed (via the reproduction IT) that there were a few more failure scenarios because the base images were importing using the same tag into the daemon so could override each-other leading to a state miss-match between Gradle and the docker daemon. 
This PR fixes that by adding the architecture to the tag.

This is to be considered a quick-fix in the interest to get the emulated lock-file generation to work. 
With so much emulation in the docker base plugin we should re-work the model to match the docker component plugin and properly represent the architecture to avoid these hard to diagnose, subtle bugs. 
