### PR TITLE
chore: remove reference to date-based image

### DIFF
--- a/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/DockerBaseImageBuildPluginIT.java
+++ b/plugins/docker/base-image/src/integrationTest/java/co/elastic/gradle/dockerbase/DockerBaseImageBuildPluginIT.java
@@ -389,7 +389,7 @@ public class DockerBaseImageBuildPluginIT extends TestkitIntegrationTest {
             }
             dockerBaseImage {
                 osPackageRepository.set(URL("https://${creds["username"]}:${creds["plaintext"]}@artifactory.elastic.dev/artifactory/gradle-plugins-os-packages"))
-                fromWolfi("docker.elastic.co/wolfi/chainguard-base", "20230214")
+                fromWolfi("docker.elastic.co/wolfi/chainguard-base", "latest")
                 install("patch")
             }
         """);


### PR DESCRIPTION
As we're now using `latest` for the `chainguard-base` image.
