### PR TITLE
Update elastic-conventions plugin to use Develocity Gradle Plugin.

### DIFF
--- a/plugins/elastic-conventions/build.gradle.kts
+++ b/plugins/elastic-conventions/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.17")
+    implementation("com.gradle.develocity:com.gradle.develocity.gradle.plugin:3.18.1")
     implementation("com.gradle:common-custom-user-data-gradle-plugin:2.0.2")
     implementation(project(":libs:utils"))
     implementation(project(":plugins:lifecycle"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ import co.elastic.gradle.vault.VaultExtension
 import java.io.File
 
 plugins {
-    id("com.gradle.enterprise").version("3.17.6")
+    id("com.gradle.develocity").version("3.18.1")
     id("co.elastic.elastic-conventions").version(File("version-released").readText().trim())
     id("co.elastic.vault").version(File("version-released").readText().trim())
 }
@@ -10,7 +10,7 @@ plugins {
 val vault:VaultExtension = extensions.findByType()!!
 val creds:Map<String, String> = vault.readAndCacheSecret("secret/ci/elastic-gradle-plugins/cloud-build-cache-us-east1").get()
 
-gradleEnterprise {
+develocity {
     buildCache {
         val isRunningInCI = System.getenv("BUILD_URL") != null || System.getenv("CI") == "true"
         remote<HttpBuildCache> {


### PR DESCRIPTION
This silences various deprecation warnings seen when running the legacy Gradle Enterprise Gradle Plugin, and makes it possible to stop using the deprecated GE plugin in downstream repos.

- Update the gradle-plugins build itself to use the Develocity plugin as well.

See e.g. https://elastic.slack.com/archives/C06TAHFDKNJ/p1729492136785869

To test this locally:

1. Run `./gradlew publishToMavenLocal`
2. Then, make the following changes:
```diff
diff --git a/settings.gradle.kts b/settings.gradle.kts
index 20fe497..7a21188 100644
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,13 @@
 import co.elastic.gradle.vault.VaultExtension
 import java.io.File

+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
 plugins {
     id("com.gradle.develocity").version("3.18.1")
     id("co.elastic.elastic-conventions").version(File("version-released").readText().trim())
```
3. Then, bump up the `version-released` file to the newer version (1.0.17)
4. Now run any Gradle command, e.g. `./gradlew tasks` and confirm it no longer has any deprecation warnings caused by the use of the legacy Gradle Enterprise plugin. You should no longer see any of the following warnings:
```
WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. Run with '-Ddevelocity.deprecation.captureOrigin=true' to see where the deprecated functionality is being used. For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.
- The deprecated "gradleEnterprise.buildScan.buildFinished" API has been replaced by "develocity.buildScan.buildFinished"
- The deprecated "gradleEnterprise.buildScan.uploadInBackground" API has been replaced by "develocity.buildScan.uploadInBackground"
- The deprecated "gradleEnterprise.buildScan.server" API has been replaced by "develocity.server"
- The deprecated "gradleEnterprise.buildScan.obfuscation.ipAddresses" API has been replaced by "develocity.buildScan.obfuscation.ipAddresses"
- The deprecated "gradleEnterprise.buildScan.value" API has been replaced by "develocity.buildScan.value"
- The deprecated "gradleEnterprise.buildScan.background" API has been replaced by "develocity.buildScan.background"
- The deprecated "gradleEnterprise.buildScan.link" API has been replaced by "develocity.buildScan.link"
- The "buildScan.publishAlways" API has been removed, the updated Develocity "buildScan.publishing" API publishes a Build Scan by default
```

Once this PR is merged and (I presume) the new version is built, I will create a follow-up PR to bump the `version-released` file to 1.0.17. That is, assuming that's the established process.

See e.g. https://github.com/elastic/cloud/pull/133411 for an example of how a downstream repo can be updated to use the newer plugin and get rid of the deprecation warnings from the older Gradle Enterprise plugin.

Noteworthy [release notes](https://docs.gradle.com/develocity/gradle-plugin/current/#release_history) from the upstream plugin:

1. Build Scan: Resource usage observability in Build Scan
2. Build Scan: Configuration cache miss reason is captured
3. Build Cache: Increase parallel remote build cache operation limit