### PR TITLE
fix(vault): correct precedence order for Vault authentication methods

### DIFF
--- a/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
+++ b/plugins/elastic-conventions/src/main/java/co/elastic/gradle/elastic_conventions/ElasticConventionsPlugin.java
@@ -249,10 +249,11 @@ public class ElasticConventionsPlugin implements Plugin<PluginAware> {
         extension.getAddress().set("https://vault-ci-prod.elastic.dev");
         final VaultAuthenticationExtension auth = extension.getExtensions()
                 .getByType(VaultAuthenticationExtension.class);
-        auth.ghTokenFile();
-        auth.ghTokenEnv();
+        // NOTE that this is in order of precedence
         auth.tokenEnv();
         auth.roleAndSecretEnv();
+        auth.ghTokenEnv();
+        auth.ghTokenFile();
     }
 
     /**


### PR DESCRIPTION
The order that we place these options into our `authMethods` matches the precedence order that we should check them in.

To mirror internal requirements, and previous plugin tooling, we should restructure this to prioritise:

1. `VAULT_TOKEN`
1. `VAULT_ROLE_ID` + `VAULT_SECRET_ID`
1. `VAULT_AUTH_GITHUB_TOKEN`
1. the contents of `~/.elastic/github.token`