### PR TITLE
Add option to set vault auth path

### DIFF
--- a/plugins/vault/src/integrationTest/java/co/elastic/gradle/vault/VaultPluginIT.java
+++ b/plugins/vault/src/integrationTest/java/co/elastic/gradle/vault/VaultPluginIT.java
@@ -305,7 +305,8 @@ public class VaultPluginIT extends TestkitIntegrationTest {
         final BuildResult result = gradleRunner
                 .withEnvironment(Map.of(
                         "VAULT_ROLE_ID", roleId,
-                        "VAULT_SECRET_ID", secret_id
+                        "VAULT_SECRET_ID", secret_id,
+                        "VAULT_AUTH_PATH", "approle"
                 ))
                 .withArguments("--warning-mode", "fail", "-s", "help")
                 .build();

--- a/plugins/vault/src/integrationTest/java/co/elastic/gradle/vault/VaultPluginIT.java
+++ b/plugins/vault/src/integrationTest/java/co/elastic/gradle/vault/VaultPluginIT.java
@@ -60,7 +60,10 @@ public class VaultPluginIT extends TestkitIntegrationTest {
     }
 
     @Test
-    void canReadVaultSecretsWithTokenAndTheyCacheCorrectly() {
+    void // The code appears to be a test case method name in Java. It suggests that the method is
+    // testing the functionality of reading vault secrets with a token and ensuring that they are
+    // cached correctly.
+    canReadVaultSecretsWithTokenAndTheyCacheCorrectly() {
         final var host = vaultContainer.getHost();
         final var firstMappedPort = vaultContainer.getFirstMappedPort();
         helper.settings(String.format("""
@@ -76,7 +79,7 @@ public class VaultPluginIT extends TestkitIntegrationTest {
                       address.set("http://%s:%s/")
                       auth {
                         tokenFile(file("no/such/token"))
-                        roleAndSecretEnv("JUST_A", "LIE")
+                        roleAndSecretEnv("IT_IS","JUST_A", "LIE")
                         roleAndSecretEnv()
                         ghTokenEnv("SOME_GH_TOKEN")
                         ghTokenEnv()
@@ -146,7 +149,7 @@ public class VaultPluginIT extends TestkitIntegrationTest {
                               address.set("http://%s:%s/")
                               auth {
                                 tokenFile(file("no/such/token"))
-                                roleAndSecretEnv("JUST_A", "LIE")
+                                roleAndSecretEnv("IT_IS","JUST_A", "LIE")
                                 roleAndSecretEnv()
                                 ghTokenEnv("SOME_GH_TOKEN")
                                 ghTokenEnv()
@@ -220,7 +223,7 @@ public class VaultPluginIT extends TestkitIntegrationTest {
                       address.set("http://%s:%s/")
                       auth {
                         tokenFile(file("no/such/token"))
-                        roleAndSecretEnv("JUST_A", "LIE")
+                        roleAndSecretEnv("IT_IS","JUST_A", "LIE")
                         roleAndSecretEnv()
                         ghTokenEnv("SOME_GH_TOKEN")
                         ghTokenEnv()

--- a/plugins/vault/src/main/java/co/elastic/gradle/vault/VaultAccessStrategy.java
+++ b/plugins/vault/src/main/java/co/elastic/gradle/vault/VaultAccessStrategy.java
@@ -44,6 +44,7 @@ public class VaultAccessStrategy {
                         try {
                             final VaultAuthenticationExtension.VaultRoleAndSecretID roleAndSecret = (VaultAuthenticationExtension.VaultRoleAndSecretID) authMethod;
                             return driver.auth().loginByAppRole(
+                                    roleAndSecret.getVaultAuthPath().get(),
                                     roleAndSecret.getRoleId().get(),
                                     roleAndSecret.getSecretId().get()
                             );


### PR DESCRIPTION
### Description

The loginByAppRole method is currently using the 'approle' path for login. This way approles created under 'service' endpoint cannot be used. The library in bettercloud provides two functions and the overloaded one will be used.

## What does this change fix

As part of work being done for replatforming our dependency management system, we discovered that the vault plugin does not support using the `service` endpoint in `/v1/auth/service/login`. Instead it uses a lbasic [function](https://github.com/BetterCloud/vault-java-driver/blob/master/src/main/java/com/bettercloud/vault/api/Auth.java#L566) of (vault-java-driver)[https://github.com/BetterCloud/vault-java-driver/] which allows login only for `/v1/auth/approle/login`:
```
    /**
     * <p>Basic login operation to authenticate to an app-role backend.  This version of the overloaded method assumes
     * that the auth backend is mounted on the default path (i.e. "/v1/auth/approle").  Example usage:</p>
     *
     * <blockquote>
     * <pre>{@code
     * final AuthResponse response = vault.auth().loginByAppRole(9e1aede8-dcc6-a293-8223-f0d824a467ed", "9ff4b26e-6460-834c-b925-a940eddb6880");
     *
     * final String token = response.getAuthClientToken();
     * }</pre>
     * </blockquote>
     *
     * @param roleId   The role-id used for authentication
     * @param secretId The secret-id used for authentication
     * @return The auth token, with additional response metadata
     * @throws VaultException If any error occurs, or unexpected response received from Vault
     */
    public AuthResponse loginByAppRole(final String roleId, final String secretId) throws VaultException {
        return loginByAppRole("approle", roleId, secretId);
    }
```
Instead, with this PR I will be [utilizing the overload method](https://github.com/BetterCloud/vault-java-driver/blob/master/src/main/java/com/bettercloud/vault/api/Auth.java#L504):
````
    /**
     * <p>Basic login operation to authenticate to an app-role backend.  This version of the overloaded method
     * requires you to explicitly specify the path on which the auth backend is mounted, following the "/v1/auth/"
     * prefix.  Example usage:</p>
     *
     * <blockquote>
     * <pre>{@code
     * final AuthResponse response = vault.auth().loginByAppRole("approle", "9e1aede8-dcc6-a293-8223-f0d824a467ed", "9ff4b26e-6460-834c-b925-a940eddb6880");
     *
     * final String token = response.getAuthClientToken();
     * }</pre>
     * </blockquote>
     * <p>
     * NOTE:  I hate that this method takes the custom mount path as its first parameter, while all of the other
     * methods in this class take it as the last parameter (a better practice).  I just didn't think about it
     * during code review.  Now it's difficult to deprecate this, since a version of the method with path as
     * the final parameter would have the same method signature.
     * <p>
     * I may or may not change this in some future breaking-change major release, especially if we keep adding
     * similar overloaded methods elsewhere and need the global consistency.  At any rate, going forward no new
     * methods should take a custom path as the first parameter.
     *
     * @param path     The path on which the authentication is performed, following the "/v1/auth/" prefix (e.g. "approle")
     * @param roleId   The role-id used for authentication
     * @param secretId The secret-id used for authentication
     * @return The auth token, with additional response metadata
     * @throws VaultException If any error occurs, or unexpected response received from Vault
     */
    public AuthResponse loginByAppRole(final String path, final String roleId, final String secretId) throws VaultException {
        int retryCount = 0;
        while (true) {
            try {
                // HTTP request to Vault
                final String requestJson = Json.object().add("role_id", roleId).add("secret_id", secretId).toString();
                final RestResponse restResponse = new Rest()//NOPMD
                        .url(config.getAddress() + "/v1/auth/" + path + "/login")
                        .header("X-Vault-Namespace", this.nameSpace)
                        .body(requestJson.getBytes(StandardCharsets.UTF_8))
                        .connectTimeoutSeconds(config.getOpenTimeout())
                        .readTimeoutSeconds(config.getReadTimeout())
                        .sslVerification(config.getSslConfig().isVerify())
                        .sslContext(config.getSslConfig().getSslContext())
                        .post();

                // Validate restResponse
                if (restResponse.getStatus() != 200) {
                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus()
                            + "\nResponse body: " + new String(restResponse.getBody(), StandardCharsets.UTF_8),
                            restResponse.getStatus());
                }
                final String mimeType = restResponse.getMimeType() == null ? "null" : restResponse.getMimeType();
                if (!mimeType.equals("application/json")) {
                    throw new VaultException("Vault responded with MIME type: " + mimeType, restResponse.getStatus());
                }
                return new AuthResponse(restResponse, retryCount);
            } catch (Exception e) {
                if (retryCount < config.getMaxRetries()) {
                    retryCount++;
                    try {
                        final int retryIntervalMilliseconds = config.getRetryIntervalMilliseconds();
                        Thread.sleep(retryIntervalMilliseconds);
                    } catch (InterruptedException e1) {
                        e1.printStackTrace();
                    }
                } else if (e instanceof VaultException) {
                    // ... otherwise, give up.
                    throw (VaultException) e;
                } else {
                    throw new VaultException(e);
                }
            }
        }
    }
```

### NOTES FOR REVIEWERS
This has not been tested as part of our integration tests.
