### PR TITLE
feat(vault): allow specifying `VAULT_AUTH_PATH` for AppRole

### DIFF
--- a/plugins/vault/src/main/java/co/elastic/gradle/vault/VaultAccessStrategy.java
+++ b/plugins/vault/src/main/java/co/elastic/gradle/vault/VaultAccessStrategy.java
@@ -44,6 +44,7 @@ public class VaultAccessStrategy {
                         try {
                             final VaultAuthenticationExtension.VaultRoleAndSecretID roleAndSecret = (VaultAuthenticationExtension.VaultRoleAndSecretID) authMethod;
                             return driver.auth().loginByAppRole(
+                                    roleAndSecret.getAuthPath().getOrElse(VaultAuthenticationExtension.VaultRoleAndSecretID.DEFAULT_VAULT_AUTH_PATH),
                                     roleAndSecret.getRoleId().get(),
                                     roleAndSecret.getSecretId().get()
                             );

--- a/plugins/vault/src/main/java/co/elastic/gradle/vault/VaultAuthenticationExtension.java
+++ b/plugins/vault/src/main/java/co/elastic/gradle/vault/VaultAuthenticationExtension.java
@@ -122,22 +122,29 @@ abstract public class VaultAuthenticationExtension {
         }
     }
 
-
     public void roleAndSecretEnv(String roleId, String secretId) {
-        authMethods.add(new VaultRoleAndSecretID(roleId, secretId));
+        authMethods.add(new VaultRoleAndSecretID(roleId, secretId, VaultRoleAndSecretID.DEFAULT_VAULT_AUTH_PATH));
     }
+
+    public void roleAndSecretEnv(String roleId, String secretId, String authPath) {
+        authMethods.add(new VaultRoleAndSecretID(roleId, secretId, authPath));
+    }
+
     @SuppressWarnings("unused")
     public void roleAndSecretEnv() {
-        roleAndSecretEnv("VAULT_ROLE_ID", "VAULT_SECRET_ID");
+        roleAndSecretEnv("VAULT_ROLE_ID", "VAULT_SECRET_ID", "VAULT_AUTH_PATH");
     }
     public class VaultRoleAndSecretID implements VaultAuthMethod {
+        public static final String DEFAULT_VAULT_AUTH_PATH = "approle";
 
         private final String roleIdName;
         private final String secretIdName;
+        private final String authPathName;
 
-        public VaultRoleAndSecretID(String roleIdName, String secretIdName) {
+        public VaultRoleAndSecretID(String roleIdName, String secretIdName, String authPathName) {
             this.roleIdName = roleIdName;
             this.secretIdName = secretIdName;
+            this.authPathName= authPathName;
         }
 
         public Provider<String> getRoleId() {
@@ -146,6 +153,10 @@ abstract public class VaultAuthenticationExtension {
 
         public Provider<String> getSecretId() {
             return getProviderFactory().environmentVariable(secretIdName);
+        }
+
+        public Provider<String> getAuthPath() {
+            return getProviderFactory().environmentVariable(authPathName);
         }
 
         @Override
@@ -157,7 +168,7 @@ abstract public class VaultAuthenticationExtension {
         public String getExplanation() {
             if (getRoleId().isPresent()) {
                 if (getSecretId().isPresent()) {
-                    return "Using environment variable `" + roleIdName + "` for role id and `" + secretIdName + "` for secret id" ;
+                    return "Using environment variable `" + roleIdName + "` for role id and `" + secretIdName + "` for secret id (for auth path `" + authPathName + "`)";
                 } else {
                     return "Tried to use environment variable `" + roleIdName + "` for role id, but environment variable `" + secretIdName + "` for secret id is not defined" ;
                 }


### PR DESCRIPTION
In the case that we're authenticating via an AppRole, but aren't using
the default `approle` auth path, we want to allow wiring in via a new
environment variable, `VAULT_AUTH_PATH`.

This duplicates the core integration test from
`canReadVaultSecretsWithRoles`, but with our new Vault auth path of
`new_path`.

If not set, this will default to `approle`.
