### PR TITLE
build: onboard to Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,35 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'maintenance'
+      - 'dependencies'
+  - title: 📝 Documentation updates
+    labels:
+      - documentation
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,4 +2,13 @@
 
 1. `./gradlew "-Pgradle.publish.secret=$(vault kv get --field=secret kv/ci-shared/release-eng/team-release-secrets/gradle-plugins/gradle_plugin_portal)" "-Pgradle.publish.key=$(vault kv get --field=key kv/ci-shared/release-eng/team-release-secrets/gradle-plugins/gradle_plugin_portal)" publishPlugins`
 1. Create a GitHub Release for the commit that's on `main` that has just been released
+  1. Browse to [the releases page](https://github.com/elastic/gradle-plugins/releases)
+  1. Click onto the latest release, which should be in Draft status
+  1. Verify that all PRs are showing up as the correctly categories
+  1 - If they are not, you will need to go into the PR itself, add the label, and then wait for Release Drafter to re-run
+  1 - If it hasn't run, you can manually nudge it [via](https://github.com/elastic/gradle-plugins/actions/workflows/release-drafter.yaml)
+  1 - Note that the next release version will be determined based on the labels in use
+  1. Click on the pencil icon (to edit)
+  1. Make any further tweaks to the release notes (as they are overridden whenever labels change on PRs)
+  1. Hit publish release
 2. Submit a PR bumping version-released and version-next after publishing to plugins.gradle.org

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "local>elastic/renovate-config:platform-devflow"
   ],
+  "addLabels": [
+    "dependencies"
+  ],
   "packageRules": [
     {
       "groupName": "Gradle Enterprise Plugin",


### PR DESCRIPTION
Similar to other (internal) projects we maintain, we should use Release
Drafter to simplify + automate the creation of tagged releases.

This will create a better set of release notes, and allow us to - in the
future - automagically release more straightforwardly.
