### PR TITLE
Migration: reassign team ownership to @elastic/builder-experience

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @elastic/platform-dev-flow
+*   @elastic/builder-experience

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -23,7 +23,7 @@ metadata:
       url: https://docs.elastic.dev/release/cloud-ci/admin
 spec:
   type: Library
-  owner: group:platform-dev-flow
+  owner: group:builder-experience
   lifecycle: beta
   dependsOn:
     - resource:github-repository-elastic-gradle-plugins
@@ -47,7 +47,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:platform-dev-flow
+  owner: group:builder-experience
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -62,4 +62,4 @@ spec:
       teams:
         everyone:
           access_level: BUILD_AND_READ
-        platform-dev-flow: {}
+        builder-experience: {}


### PR DESCRIPTION
Part of the EngProd GitHub team migration (parent: [#2148](https://github.com/elastic/platform-engineering-productivity/issues/2148), this touchpoint: [#2426](https://github.com/elastic/platform-engineering-productivity/issues/2426)).

**⚠️ DO NOT MERGE** until migration day. PRs are merged in batches grouped by new team owner so the [Terrazzo](https://github.com/elastic/terrazzo) wild plan for each batch can be reviewed and approved independently.


### Files changed

- `CODEOWNERS` (1 line)
- `catalog-info.yaml` (3 lines)

---

Generated by `scripts/github-team-migration/open_repo_prs.py`.